### PR TITLE
Update p2p version string to not get banned by daemon

### DIFF
--- a/packages/bitcore-p2p/lib/messages/commands/version.js
+++ b/packages/bitcore-p2p/lib/messages/commands/version.js
@@ -37,7 +37,7 @@ function VersionMessage(arg, options) {
   this.nonce = arg.nonce || utils.getNonce();
   this.services = arg.services || new BN(1, 10);
   this.timestamp = arg.timestamp || new Date();
-  this.subversion = arg.subversion || '/Satoshi:0.14.0.0/'; //+ packageInfo.version + '/';
+  this.subversion = arg.subversion || '/Satoshi:0.14.10.0/'; //+ packageInfo.version + '/';
   this.startHeight = arg.startHeight || 0;
   this.relay = arg.relay === false ? false : true;
 }


### PR DESCRIPTION
This firo PR https://github.com/firoorg/firo/pull/1108 bans clients less then 14.9.0 and bitcore-firo was sending 14.0.0, however the protocol messages are kept up to date.